### PR TITLE
feat: add minecraft server portal toy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gosuda/portal-toys
 
 go 1.26.1
 
-replace github.com/gosuda/portal/v2 => github.com/gosuda/portal-tunnel/v2 v2.1.1
+replace github.com/gosuda/portal/v2 => github.com/gosuda/portal-tunnel/v2 v2.1.2-0.20260403064421-440cea4f22c6
 
 require (
 	github.com/cockroachdb/pebble/v2 v2.1.4

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuda/keyless_tls v0.0.1-0.20260304212324-7733f8366abc h1:aS9LQ35x6EtrGKCmOWRj6Y9aQ2l5hP8dVva4oxB9VEg=
 github.com/gosuda/keyless_tls v0.0.1-0.20260304212324-7733f8366abc/go.mod h1:BOhUZgiAAQzxKO3QcC4fCXgd/+lqxgIu1OyIYTqtta8=
-github.com/gosuda/portal-tunnel/v2 v2.1.1 h1:aUGE+e668cyYQpHTE+qf8JLo1nT7RrYIkuYXGs+j9Oo=
-github.com/gosuda/portal-tunnel/v2 v2.1.1/go.mod h1:dFmGGY70+N7kmQTq8yoIiRVrbGpQSTBsRvcs+J1XSIs=
+github.com/gosuda/portal-tunnel/v2 v2.1.2-0.20260403064421-440cea4f22c6 h1:lVDQ7vC8AdAec7qiZILohsA1huWTP+KhZMGdGNB/2rg=
+github.com/gosuda/portal-tunnel/v2 v2.1.2-0.20260403064421-440cea4f22c6/go.mod h1:dFmGGY70+N7kmQTq8yoIiRVrbGpQSTBsRvcs+J1XSIs=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=

--- a/minecraft/bootstrap.go
+++ b/minecraft/bootstrap.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"embed"
+	"os"
+)
+
+//go:embed static
+var embeddedStatic embed.FS
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/minecraft/main.go
+++ b/minecraft/main.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gosuda/portal/v2/sdk"
+	"github.com/gosuda/portal/v2/types"
+	"github.com/gosuda/portal/v2/utils"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "minecraft",
+	Short: "Portal Minecraft server proxy with status dashboard",
+	RunE:  runMinecraft,
+}
+
+var (
+	flagServerURLs   string
+	flagDiscovery    bool
+	flagBanMITM      bool
+	flagPort         int
+	flagName         string
+	flagIdentityPath string
+	flagHide         bool
+	flagDescription  string
+	flagTags         string
+	flagOwner        string
+	flagMCAddr       string
+	flagTCPAddr      string
+)
+
+func init() {
+	flags := rootCmd.PersistentFlags()
+	flags.StringVar(&flagServerURLs, "server-url", getEnv("RELAY", ""), "relay base URL(s); comma-separated (env: RELAY)")
+	flags.BoolVar(&flagDiscovery, "discovery", utils.ResolveBoolEnv(true, "DISCOVERY", "DEFAULT_RELAYS"), "enable relay discovery [env: DISCOVERY]")
+	flags.BoolVar(&flagBanMITM, "ban-mitm", utils.ResolveBoolEnv(false, "BAN_MITM"), "ban relay on MITM detection [env: BAN_MITM]")
+	flags.IntVar(&flagPort, "port", 3000, "local HTTP dashboard port (negative to disable)")
+	flags.StringVar(&flagName, "name", getEnv("MC_NAME", "minecraft"), "service display name (env: MC_NAME)")
+	flags.StringVar(&flagIdentityPath, "identity-path", "identity.json", "path to load/save portal identity")
+	flags.BoolVar(&flagHide, "hide", false, "hide from relay listings")
+	flags.StringVar(&flagDescription, "description", getEnv("MC_DESCRIPTION", "Minecraft server via Portal"), "lease description")
+	flags.StringVar(&flagTags, "tags", getEnv("MC_TAGS", "game,minecraft"), "comma-separated lease tags")
+	flags.StringVar(&flagOwner, "owner", getEnv("MC_OWNER", "Minecraft"), "lease owner")
+	flags.StringVar(&flagMCAddr, "mc-addr", getEnv("MC_ADDR", "localhost:25565"), "local Minecraft server address (env: MC_ADDR)")
+	flags.StringVar(&flagTCPAddr, "tcp-addr", getEnv("TCP_ADDR", ""), "relay TCP address to display on dashboard (env: TCP_ADDR)")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal().Err(err).Msg("execute minecraft command")
+	}
+}
+
+func runMinecraft(cmd *cobra.Command, args []string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Prepare static files for dashboard
+	staticFS, err := fs.Sub(embeddedStatic, "static")
+	if err != nil {
+		return fmt.Errorf("embed sub FS: %w", err)
+	}
+
+	// HTTP dashboard handler
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", handleStatus)
+	mux.Handle("/", http.FileServer(http.FS(staticFS)))
+
+	// Start local HTTP dashboard
+	if flagPort >= 0 {
+		addr := fmt.Sprintf(":%d", flagPort)
+		go func() {
+			log.Info().Str("addr", addr).Msg("[minecraft] dashboard started")
+			if err := http.ListenAndServe(addr, mux); err != nil && err != http.ErrServerClosed {
+				log.Error().Err(err).Msg("[minecraft] dashboard server error")
+			}
+		}()
+	}
+
+	// Expose via portal SDK with TCP port routing
+	exposure, err := sdk.Expose(ctx, sdk.ExposeConfig{
+		RelayURLs:    utils.SplitCSV(flagServerURLs),
+		TCPEnabled:   true,
+		TargetAddr:   flagMCAddr,
+		Discovery:    flagDiscovery,
+		BanMITM:      flagBanMITM,
+		Name:         flagName,
+		IdentityPath: flagIdentityPath,
+		Metadata: types.LeaseMetadata{
+			Description: flagDescription,
+			Tags:        utils.SplitCSV(flagTags),
+			Owner:       flagOwner,
+			Hide:        flagHide,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("expose: %w", err)
+	}
+	defer func() {
+		if err := exposure.Close(); err != nil {
+			log.Warn().Err(err).Msg("[minecraft] close exposure")
+		}
+	}()
+
+	log.Info().
+		Str("mc_addr", flagMCAddr).
+		Str("tcp_addr", flagTCPAddr).
+		Strs("relays", exposure.ActiveRelayURLs()).
+		Msg("[minecraft] portal tunnel started; proxying MC connections")
+
+	// Close exposure on context cancellation
+	go func() {
+		<-ctx.Done()
+		_ = exposure.Close()
+	}()
+
+	// Accept relay connections and proxy to MC server
+	var wg sync.WaitGroup
+	for {
+		conn, err := exposure.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				break // graceful shutdown
+			}
+			log.Error().Err(err).Msg("[minecraft] accept error")
+			break
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proxyToMC(ctx, conn, flagMCAddr)
+		}()
+	}
+
+	wg.Wait()
+	log.Info().Msg("[minecraft] shutdown complete")
+	return nil
+}
+
+func proxyToMC(ctx context.Context, relayConn net.Conn, mcAddr string) {
+	defer relayConn.Close()
+
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	mcConn, err := dialer.DialContext(ctx, "tcp", mcAddr)
+	if err != nil {
+		log.Warn().Err(err).Str("mc_addr", mcAddr).Msg("[minecraft] dial MC server failed")
+		return
+	}
+	defer mcConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(mcConn, relayConn)
+		close(done)
+	}()
+	_, _ = io.Copy(relayConn, mcConn)
+	<-done
+}
+
+func handleStatus(w http.ResponseWriter, r *http.Request) {
+	resp := map[string]interface{}{
+		"tcp_addr": flagTCPAddr,
+	}
+
+	status, err := PingServer(flagMCAddr, 3*time.Second)
+	if err != nil {
+		resp["online"] = false
+		resp["error"] = err.Error()
+	} else {
+		resp["online"] = true
+		resp["motd"] = ExtractMOTD(status.Description)
+		resp["players"] = status.Players.Online
+		resp["max_players"] = status.Players.Max
+		resp["version"] = status.Version.Name
+		resp["favicon"] = status.Favicon
+		resp["error"] = ""
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Error().Err(err).Msg("[minecraft] encode status response")
+	}
+}

--- a/minecraft/ping.go
+++ b/minecraft/ping.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// ServerStatus represents the response from a Minecraft Server List Ping.
+type ServerStatus struct {
+	Description interface{} `json:"description"`
+	Players     struct {
+		Max    int `json:"max"`
+		Online int `json:"online"`
+	} `json:"players"`
+	Version struct {
+		Name     string `json:"name"`
+		Protocol int    `json:"protocol"`
+	} `json:"version"`
+	Favicon string `json:"favicon,omitempty"`
+}
+
+// PingServer performs a Minecraft Java Edition Server List Ping and returns the server status.
+func PingServer(addr string, timeout time.Duration) (*ServerStatus, error) {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+		portStr = "25565"
+	}
+	var port uint16
+	if _, err := fmt.Sscanf(portStr, "%d", &port); err != nil {
+		return nil, fmt.Errorf("parse port %q: %w", portStr, err)
+	}
+
+	// Send Handshake packet (ID 0x00)
+	handshake := buildHandshake(host, port)
+	if err := writePacket(conn, 0x00, handshake); err != nil {
+		return nil, fmt.Errorf("write handshake: %w", err)
+	}
+
+	// Send Status Request packet (ID 0x00, empty payload)
+	if err := writePacket(conn, 0x00, nil); err != nil {
+		return nil, fmt.Errorf("write status request: %w", err)
+	}
+
+	// Read Status Response
+	packetID, payload, err := readPacket(conn)
+	if err != nil {
+		return nil, fmt.Errorf("read status response: %w", err)
+	}
+	if packetID != 0x00 {
+		return nil, fmt.Errorf("unexpected packet ID: 0x%02x", packetID)
+	}
+
+	// Payload is a length-prefixed JSON string
+	jsonStr, err := readString(payload)
+	if err != nil {
+		return nil, fmt.Errorf("read json string: %w", err)
+	}
+
+	var status ServerStatus
+	if err := json.Unmarshal([]byte(jsonStr), &status); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	return &status, nil
+}
+
+// ExtractMOTD extracts a plain text MOTD from the Description field.
+func ExtractMOTD(desc interface{}) string {
+	switch v := desc.(type) {
+	case string:
+		return v
+	case map[string]interface{}:
+		if text, ok := v["text"].(string); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func buildHandshake(host string, port uint16) []byte {
+	var buf []byte
+	buf = appendVarInt(buf, 767) // protocol version (1.21.4)
+	buf = appendString(buf, host)
+	buf = binary.BigEndian.AppendUint16(buf, port)
+	buf = appendVarInt(buf, 1) // next state: status
+	return buf
+}
+
+func writePacket(w io.Writer, packetID int32, payload []byte) error {
+	var idBuf []byte
+	idBuf = appendVarInt(idBuf, packetID)
+
+	packetLen := len(idBuf) + len(payload)
+	var lenBuf []byte
+	lenBuf = appendVarInt(lenBuf, int32(packetLen))
+
+	if _, err := w.Write(lenBuf); err != nil {
+		return err
+	}
+	if _, err := w.Write(idBuf); err != nil {
+		return err
+	}
+	if len(payload) > 0 {
+		if _, err := w.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readPacket(r io.Reader) (packetID int32, payload io.Reader, err error) {
+	length, err := readVarInt(r)
+	if err != nil {
+		return 0, nil, fmt.Errorf("read packet length: %w", err)
+	}
+	if length < 1 || length > 32768 {
+		return 0, nil, fmt.Errorf("invalid packet length: %d", length)
+	}
+
+	data := make([]byte, length)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return 0, nil, fmt.Errorf("read packet data: %w", err)
+	}
+
+	// First VarInt in data is the packet ID
+	var offset int
+	packetID, offset = decodeVarInt(data)
+	return packetID, newByteReader(data[offset:]), nil
+}
+
+func appendVarInt(buf []byte, val int32) []byte {
+	uval := uint32(val)
+	for {
+		b := byte(uval & 0x7F)
+		uval >>= 7
+		if uval != 0 {
+			b |= 0x80
+		}
+		buf = append(buf, b)
+		if uval == 0 {
+			break
+		}
+	}
+	return buf
+}
+
+func readVarInt(r io.Reader) (int32, error) {
+	var result uint32
+	var shift uint
+	single := make([]byte, 1)
+	for i := 0; i < 5; i++ {
+		if _, err := io.ReadFull(r, single); err != nil {
+			return 0, err
+		}
+		b := single[0]
+		result |= uint32(b&0x7F) << shift
+		if b&0x80 == 0 {
+			return int32(result), nil
+		}
+		shift += 7
+	}
+	return 0, fmt.Errorf("varint too long")
+}
+
+func decodeVarInt(data []byte) (int32, int) {
+	var result uint32
+	var shift uint
+	for i := 0; i < len(data) && i < 5; i++ {
+		b := data[i]
+		result |= uint32(b&0x7F) << shift
+		if b&0x80 == 0 {
+			return int32(result), i + 1
+		}
+		shift += 7
+	}
+	return 0, 1 // malformed: consume at least 1 byte to avoid infinite loop
+}
+
+func appendString(buf []byte, s string) []byte {
+	buf = appendVarInt(buf, int32(len(s)))
+	buf = append(buf, s...)
+	return buf
+}
+
+func readString(r io.Reader) (string, error) {
+	length, err := readVarInt(r)
+	if err != nil {
+		return "", err
+	}
+	if length < 0 || length > 32768 {
+		return "", fmt.Errorf("invalid string length: %d", length)
+	}
+	data := make([]byte, length)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+type byteReader struct {
+	data []byte
+	pos  int
+}
+
+func newByteReader(data []byte) *byteReader {
+	return &byteReader{data: data}
+}
+
+func (br *byteReader) Read(p []byte) (int, error) {
+	if br.pos >= len(br.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, br.data[br.pos:])
+	br.pos += n
+	return n, nil
+}

--- a/minecraft/static/index.html
+++ b/minecraft/static/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Minecraft Server — Portal Toy</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #1a1a2e;
+    color: #e0e0e0;
+    font-family: 'Courier New', monospace;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .container {
+    background: #16213e;
+    border: 2px solid #0f3460;
+    border-radius: 8px;
+    padding: 32px;
+    max-width: 480px;
+    width: 90%;
+  }
+  h1 {
+    color: #53a653;
+    font-size: 20px;
+    margin-bottom: 24px;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  .status-badge {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+  }
+  .status-badge.online { background: #2d6a2d; color: #7cfc7c; }
+  .status-badge.offline { background: #6a2d2d; color: #fc7c7c; }
+  .info-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid #0f3460;
+  }
+  .info-row:last-child { border-bottom: none; }
+  .info-label { color: #8888aa; font-size: 13px; }
+  .info-value { color: #e0e0e0; font-size: 14px; font-weight: bold; }
+  .connect-box {
+    margin-top: 20px;
+    background: #0f3460;
+    border-radius: 6px;
+    padding: 16px;
+    text-align: center;
+  }
+  .connect-label { color: #8888aa; font-size: 12px; margin-bottom: 8px; }
+  .connect-addr {
+    color: #53a653;
+    font-size: 18px;
+    font-weight: bold;
+    word-break: break-all;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 4px;
+    transition: background 0.2s;
+  }
+  .connect-addr:hover { background: #1a1a3e; }
+  .copy-hint { color: #666; font-size: 11px; margin-top: 6px; }
+  .copied { color: #53a653 !important; }
+  .error-msg { color: #fc7c7c; font-size: 13px; margin-top: 8px; text-align: center; }
+  .loading { color: #8888aa; text-align: center; padding: 40px 0; }
+  .motd { color: #aaaacc; font-style: italic; }
+  .server-icon {
+    width: 64px;
+    height: 64px;
+    image-rendering: pixelated;
+    border-radius: 4px;
+    border: 2px solid #0f3460;
+  }
+  .header-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #0f3460;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>&#9878; Minecraft Server</h1>
+  <div id="content">
+    <div class="loading">Loading server status...</div>
+  </div>
+</div>
+<script>
+async function loadStatus() {
+  const el = document.getElementById('content');
+  try {
+    const res = await fetch('/api/status');
+    const data = await res.json();
+    if (data.online) {
+      el.innerHTML = `
+        ${data.favicon ? `
+        <div class="header-row">
+          <img class="server-icon" src="${data.favicon}" alt="Server Icon">
+          <div>
+            <div class="status-badge online">Online</div>
+            <div class="motd" style="margin-top:6px">${esc(data.motd || 'N/A')}</div>
+          </div>
+        </div>` : `
+        <div class="info-row">
+          <span class="info-label">Status</span>
+          <span class="status-badge online">Online</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">MOTD</span>
+          <span class="info-value motd">${esc(data.motd || 'N/A')}</span>
+        </div>`}
+        <div class="info-row">
+          <span class="info-label">Players</span>
+          <span class="info-value">${data.players} / ${data.max_players}</span>
+        </div>
+        <div class="info-row">
+          <span class="info-label">Version</span>
+          <span class="info-value">${esc(data.version || 'N/A')}</span>
+        </div>
+        ${data.tcp_addr ? `
+        <div class="connect-box">
+          <div class="connect-label">Server Address</div>
+          <div class="connect-addr" onclick="copyAddr(this)" title="Click to copy">${esc(data.tcp_addr)}</div>
+          <div class="copy-hint" id="copy-hint">Click to copy</div>
+        </div>` : ''}
+      `;
+    } else {
+      el.innerHTML = `
+        <div class="info-row">
+          <span class="info-label">Status</span>
+          <span class="status-badge offline">Offline</span>
+        </div>
+        <div class="error-msg">${esc(data.error || 'Server is not responding')}</div>
+        ${data.tcp_addr ? `
+        <div class="connect-box">
+          <div class="connect-label">Server Address (when online)</div>
+          <div class="connect-addr" onclick="copyAddr(this)" title="Click to copy">${esc(data.tcp_addr)}</div>
+          <div class="copy-hint" id="copy-hint">Click to copy</div>
+        </div>` : ''}
+      `;
+    }
+  } catch (e) {
+    el.innerHTML = `<div class="error-msg">Failed to load status: ${esc(e.message)}</div>`;
+  }
+}
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+function copyAddr(el) {
+  navigator.clipboard.writeText(el.textContent.trim()).then(() => {
+    const hint = document.getElementById('copy-hint');
+    if (hint) { hint.textContent = 'Copied!'; hint.classList.add('copied'); }
+    setTimeout(() => {
+      if (hint) { hint.textContent = 'Click to copy'; hint.classList.remove('copied'); }
+    }, 2000);
+  });
+}
+loadStatus();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Minecraft Java Edition 서버를 portal relay TCP port routing으로 노출하는 새 portal toy
- 로컬 웹 대시보드에서 서버 상태(MOTD, 플레이어 수, 버전, 서버 아이콘) 확인 가능
- portal-toys 레포 최초의 TCP 기반 toy (PR gosuda/portal-tunnel#174 의존)

## How it works
```
MC Client → Relay TCP Port (40000+) → exposure.Accept() → proxyToMC() → localhost:25565
Browser  → localhost:3030           → /api/status       → MC Server List Ping → JSON
```

## Key files
| File | Description |
|------|-------------|
| `minecraft/main.go` | Cobra CLI + `sdk.Expose(TCPEnabled)` + Accept proxy loop + local HTTP dashboard |
| `minecraft/ping.go` | MC Server List Ping protocol (VarInt, Handshake, Status Request/Response) |
| `minecraft/bootstrap.go` | Embed static assets |
| `minecraft/static/index.html` | Status dashboard with MC theme |

## Usage
```bash
go run ./minecraft/ \
  --server-url https://portal.thumbgo.kr/relay \
  --mc-addr localhost:25565 \
  --tcp-addr portal.thumbgo.kr:40001
```

## Dependencies
- Requires portal SDK with `TCPEnabled` support (gosuda/portal-tunnel#174)
- go.mod updated to `feature/tcp-port-routing` branch (`440cea4f`)

## Test plan
- [x] `go build` / `go vet` pass
- [x] Dashboard shows "Offline" when no MC server running
- [x] Dashboard shows server status (MOTD, players, version) when MC server running
- [ ] MC client connects via relay TCP address (requires relay with TCP port routing enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)